### PR TITLE
fix route for navlink of maxirecipecard

### DIFF
--- a/client/src/components/MaxiRecipeCard.jsx
+++ b/client/src/components/MaxiRecipeCard.jsx
@@ -6,7 +6,7 @@ import NutValueElement from "./NutValueElement";
 
 function MaxiRecipeCard({ title, duration, photo, nutValue, id }) {
   return (
-    <NavLink to={`recipe/${id}`}>
+    <NavLink to={`/popote/recipe/${id}`}>
       <section className="recipe-card">
         <img
           id="recipe-card-img"

--- a/client/src/pages/SearchPage.jsx
+++ b/client/src/pages/SearchPage.jsx
@@ -30,6 +30,7 @@ function SearchPage() {
           filteredRecipe.map((el) => (
             <MaxiRecipeCard
               key={el.id}
+              id={el.id}
               title={el.title}
               duration={el.duration}
               photo={el.url_photo}


### PR DESCRIPTION
Branch pour fixer un problème de NavLink.

MaxiRecipeCard : 
- Modification de la route NavLink pour pointer sur /popote/recipe/${id} quel que soit l'endroit de l'utilisateur

SearchPage : 
- Ajout de la props "Id" sur la map de MaxiRecipeCard afin de rendre l'injection d'id disponible au clic de MaxiRecipeCard depuis la page SearchPage